### PR TITLE
Update 2412 website link

### DIFF
--- a/_frc/2400/2412.md
+++ b/_frc/2400/2412.md
@@ -18,7 +18,7 @@ team:
     - Platt Electric
     - Sammamish Senior High
   links:
-    Website: http://first.robototes.com
+    Website: http://www.robototes.com
     Github: http://github.com/robototes
 robot_code:
   2016:


### PR DESCRIPTION
Updated 2412's website link from first.robototes.com (old site) to www.robototes.com (new site).